### PR TITLE
make fade-functions independent of min/max brightness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,15 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run tests
       run: |
         pip install ".[optional]"
@@ -40,18 +40,18 @@ jobs:
         tr '_' '-'
         )
     - name: Set up Python 3.x
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Versions
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Checkout tools repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
@@ -72,7 +72,7 @@ jobs:
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --package_folder_prefix "" --library_location .
     - name: Archive bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: bundles
         path: ${{ github.workspace }}/bundles/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 # following via commandline, replacing "path/to/your/" with the actual path to your newly created
 # .gitignore_global file:
 # git config --global core.excludesfile path/to/your/.gitignore_global
-
+uv.lock
 .coverage
 .direnv
 .envrc

--- a/README.rst
+++ b/README.rst
@@ -88,13 +88,13 @@ To install in a virtual environment in your current project:
 Installing to a Connected CircuitPython Device with Circup
 ----------------------------------------------------------
 
-``JLed`` is available in the `Circuitpython Community Bundle <https://github.com/adafruit/CircuitPython_Community_Bundle>`_ 
-and can easily installed with `circup <https://pypi.org/project/circup/>`_ by 
+``JLed`` is available in the `Circuitpython Community Bundle <https://github.com/adafruit/CircuitPython_Community_Bundle>`_
+and can easily installed with `circup <https://pypi.org/project/circup/>`_ by
 running::
 
     $ circup install jled
 
-Optionally copy also one of the example as ``code.py`` to the root of the filesystem. 
+Optionally copy also one of the example as ``code.py`` to the root of the filesystem.
 
 Installing on a MicroPython device
 ----------------------------------
@@ -102,7 +102,7 @@ Installing on a MicroPython device
 Create a directory called ``jled`` on the device and `copy
 <https://pypi.org/project/mpremote/>`_ the following files into this directory:
 ``jled.py``, ``jled_sequence.py`` ``hal_pwm_micropython.py``,
-``hal_time_micropython.py``, ``play.py``, ``__init__.py```. Optionally also copy 
+``hal_time_micropython.py``, ``play.py``, ``__init__.py```. Optionally also copy
 one of the example as ``main.py`` to the root of the filesystem.  The overall
 structure is:
 
@@ -144,6 +144,20 @@ Unit tests (using https://docs.pytest.org) are provided, run the tests with:
    $ pytest
 
 To run the ``pre-commit-hook`` locally, run ``pre-commit run --all-files``
+
+Tip
+===
+
+Instead of installing the various tools like ``circup``, ``mp-remote``,
+``mpy-cross`` etc. you can easily run the tools using `uv
+<https://docs.astral.sh/uv/>`:
+
+- ``uv tool run circup list``, ``uv tool run circup update --all``
+- ``uv tool run mpremote`` to start a REPL on the micro controller
+- ``uv tool run --with pytest-cov pytest`` to run the unit tests
+- ``uv tool run --from sphinx sphinx-build -E -W -b html . build/html`` to build
+  the documentation using sphinx (run inside ``docs/``)
+
 
 Author & Copyright
 ==================

--- a/README.rst
+++ b/README.rst
@@ -149,8 +149,7 @@ Tip
 ===
 
 Instead of installing the various tools like ``circup``, ``mp-remote``,
-``mpy-cross`` etc. you can easily run the tools using `uv
-<https://docs.astral.sh/uv/>`:
+``mpy-cross`` etc. you can easily run the tools using `uv <https://docs.astral.sh/uv/>`_:
 
 - ``uv tool run circup list``, ``uv tool run circup update --all``
 - ``uv tool run mpremote`` to start a REPL on the micro controller

--- a/README.rst
+++ b/README.rst
@@ -101,10 +101,10 @@ Installing on a MicroPython device
 
 Create a directory called ``jled`` on the device and `copy
 <https://pypi.org/project/mpremote/>`_ the following files into this directory:
-into this directory: ``jled.py``, ``jled_sequence.py``
-``hal_pwm_micropython.py``, ``hal_time_micropython.py``, ``play.py``,
-``__init__.py```. Optionally also copy one of the example as ``main.py`` to the
-root of the filesystem.  The overall structure is:
+``jled.py``, ``jled_sequence.py`` ``hal_pwm_micropython.py``,
+``hal_time_micropython.py``, ``play.py``, ``__init__.py```. Optionally also copy 
+one of the example as ``main.py`` to the root of the filesystem.  The overall
+structure is:
 
 .. code-block::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,10 +121,10 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
         import sphinx_rtd_theme
 
         html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
+#        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
     except:
         html_theme = "default"
-        html_theme_path = ["."]
+#        html_theme_path = ["."]
 else:
     html_theme_path = ["."]
 

--- a/examples/jled_pulse.py
+++ b/examples/jled_pulse.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Jan Delgado
+# SPDX-License-Identifier: MIT
+"""
+JLed pulse example
+"""
+
+import board
+from jled import JLed
+
+led = JLed(board.LED).breathe(2000).min_brightness(20).max_brightness(200).forever()
+
+while True:
+    led.update()

--- a/jled/jled.py
+++ b/jled/jled.py
@@ -81,13 +81,19 @@ class _BlinkBrightnessEval:
 
 
 class _BreatheBrightnessEval:
-    def __init__(self, duration_fade_on, duration_on, duration_fade_off,
-                 from_=0, to=FULL_BRIGHTNESS):
+    def __init__(
+        self,
+        duration_fade_on,
+        duration_on,
+        duration_fade_off,
+        start=0,
+        end=FULL_BRIGHTNESS,
+    ):
         self._duration_fade_on = duration_fade_on
         self._duration_on = duration_on
         self._duration_fade_off = duration_fade_off
-        self._from = from_
-        self._to = to
+        self._start = start
+        self._end = end
 
     def period(self):
         return self._duration_fade_on + self._duration_on + self._duration_fade_off
@@ -100,7 +106,7 @@ class _BreatheBrightnessEval:
             val = FULL_BRIGHTNESS
         else:
             val = fadeon_func(self.period() - t, self._duration_fade_off)
-        return lerp8by8(val, self._from, self._to)
+        return lerp8by8(val, self._start, self._end)
 
 
 class _CandleBrightnessEval:
@@ -228,7 +234,7 @@ class JLed:
         """
         return self._set_brightness_eval(_ConstantBrightnessEval(brightness, period))
 
-    def fade_on(self, period, from_ = 0, to = FULL_BRIGHTNESS):
+    def fade_on(self, period, start=0, end=FULL_BRIGHTNESS):
         """In fade_on mode, the LED is smoothly faded on to 100% brightness
         using PWM. The ``fade_on`` method takes the period of the effect as an
         argument.
@@ -238,31 +244,37 @@ class JLed:
         <https://www.wolframalpha.com/input/?i=plot+(exp(sin((t-1000%2F2.)*PI%2F1000))-0.36787944)*108.0++t%3D0+to+1000>`_.
 
         :param period: period of the effect
+        :param: start: start brightness
+        :param: end: end brightness
 
         :return: this JLed instance
         """
-        return self._set_brightness_eval(_BreatheBrightnessEval(period, 0, 0, from_, to))
+        return self._set_brightness_eval(
+            _BreatheBrightnessEval(period, 0, 0, start, end)
+        )
 
-    def fade_off(self, period, from_ = FULL_BRIGHTNESS, to = 0):
+    def fade_off(self, period, start=FULL_BRIGHTNESS, end=0):
         """In fade_off mode, the LED is smoothly faded off using PWM. The fade
         starts at 100% brightness. Internally it is implemented as a mirrored
         version of the :func:`fade_on` function, i.e.
         ``fade_off(t) = fade_on(period-t)``.
 
         :param period: period of the effect
+        :param: start: start brightness
+        :param: end: end brightness
 
         :return: this JLed instance
         """
-        return self._set_brightness_eval(_BreatheBrightnessEval(0, 0, period, from_, to))
+        return self._set_brightness_eval(
+            _BreatheBrightnessEval(0, 0, period, start, end)
+        )
 
     def fade(self, start, end, period):
         """The fade effect allows to fade from any start value ``start`` to
-        any target value ``end`` with the given period. Internally it sets up a
-        :func:`fade` or :func:`fade_off` effect and :func:`min_brightness` and
-        :func:`max_brightness` values properly.
+        any target value ``end`` with the given period.
 
-        :param start: start brightness values
-        :param end: end brightness value
+        :param start: start brightness
+        :param end: end brightness
         :param period: period of the effect
 
         :return: this JLed instance

--- a/tests/test_jled.py
+++ b/tests/test_jled.py
@@ -43,7 +43,6 @@ def test_breathe_brightness_evalulates_curve():
     assert 255 == fx.eval(30)
     assert 0 < fx.eval(31)
     assert 0 == fx.eval(59)
-    assert 0 == fx.eval(100)
 
 
 def test_candle_brightness_evalulater():
@@ -264,39 +263,35 @@ def test_breathe_with_custom_params_sets_breathe_brightness_eval():
     led = JLed(1).breathe(100, 200, 300)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
     assert (
-        _BreatheBrightnessEval(100, 200, 300).__dict__ == led._brightness_eval.__dict__
+        _BreatheBrightnessEval(100, 200, 300, 0, 255).__dict__ == led._brightness_eval.__dict__
     )
 
 
 def test_breathe_sets_breathe_brightness_eval():
     led = JLed(1).breathe(100)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
-    assert _BreatheBrightnessEval(50, 0, 50).__dict__ == led._brightness_eval.__dict__
+    assert _BreatheBrightnessEval(50, 0, 50, 0, 255).__dict__ == led._brightness_eval.__dict__
 
 
 def test_fadeon_sets_breathe_brightness_eval():
     led = JLed(1).fade_on(100)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
-    assert _BreatheBrightnessEval(100, 0, 0).__dict__ == led._brightness_eval.__dict__
+    assert _BreatheBrightnessEval(100, 0, 0, 0, 255).__dict__ == led._brightness_eval.__dict__
 
 
 def test_fadeoff_sets_breathe_brightness_eval():
     led = JLed(1).fade_off(100)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
-    assert _BreatheBrightnessEval(0, 0, 100).__dict__ == led._brightness_eval.__dict__
+    assert _BreatheBrightnessEval(0, 0, 100, 255, 0).__dict__ == led._brightness_eval.__dict__
 
 
 def test_fade_from_low_to_high_sets_breathe_brightness_eval_and_brightness():
     led = JLed(1).fade(start=100, end=200, period=300)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
-    assert _BreatheBrightnessEval(300, 0, 0).__dict__ == led._brightness_eval.__dict__
-    assert 100 == led._min_brightness
-    assert 200 == led._max_brightness
+    assert _BreatheBrightnessEval(300, 0, 0, 100, 200).__dict__ == led._brightness_eval.__dict__
 
 
 def test_fade_from_high_to_low_sets_breathe_brightness_eval_and_brightness():
     led = JLed(1).fade(start=200, end=100, period=300)
     assert isinstance(led._brightness_eval, _BreatheBrightnessEval)
-    assert _BreatheBrightnessEval(0, 0, 300).__dict__ == led._brightness_eval.__dict__
-    assert 100 == led._min_brightness
-    assert 200 == led._max_brightness
+    assert _BreatheBrightnessEval(0, 0, 300, 200, 100).__dict__ == led._brightness_eval.__dict__


### PR DESCRIPTION
Make behaviour on par with the c++ version of jled. before, min/max brightness functions could not be used together with the fade functions. now this is possible and a "pulse" effect can be made with, e.g.
`JLed(board.GP17).breathe(2500).min_brightness(20).max_brightness(200)`

Addresses #6 